### PR TITLE
Fix OrgScore2_1_1 to pass if Bluetooth is off but there are paired devices

### DIFF
--- a/Fragments/OrgScores/OrgScore2_1_1.sh
+++ b/Fragments/OrgScores/OrgScore2_1_1.sh
@@ -20,19 +20,24 @@ if [[ "${auditResult}" == "1" ]]; then
 	bluetoothEnabled=$(defaults read /Library/Preferences/com.apple.Bluetooth ControllerPowerState -bool)
 	comment="Paired Devices: ${connectable}"
 	# if [[ "$connectable" == 0 ]] && [[ "$bluetoothEnabled" == 0 ]]; then
-	if [[ "$connectable" -gt 0 ]] && [[ "$bluetoothEnabled" == 1 ]] || [[ "$connectable" == 0 ]] && [[ "$bluetoothEnabled" == 0 ]]; then
+	if [[ "$bluetoothEnabled" == 0 ]]; then
+		# bluetooth is off: passes
+		result="Passed"
+	elif [[ "$bluetoothEnabled" == 1 ]] && [[ "$connectable"-gt 0 ]]; then
+	        # bluetooth is on, and there are paired devices: passes
 		result="Passed"
 	else
 		result="Failed"
-		comment="No Paired Devices"
+		comment="Bluetooth On With No Paired Devices"
 		# Remediation
 		if [[ "${remediateResult}" == "enabled" ]]; then
 			defaults write /Library/Preferences/com.apple.Bluetooth ControllerPowerState -bool false
 			killall -HUP bluetoothd
 			# re-check
-			connectable=$(system_profiler SPBluetoothDataType 2>&1 | grep -c "Paired: Yes")
+			# our remediation is turning Bluetooth off so no need to check for paired devices
+			# connectable=$(system_profiler SPBluetoothDataType 2>&1 | grep -c "Paired: Yes")
 			bluetoothEnabled=$(defaults read /Library/Preferences/com.apple.Bluetooth ControllerPowerState -bool)
-			if [[ "$connectable" == 0 ]] && [[ "$bluetoothEnabled" == 0 ]]; then
+			if [[ "$bluetoothEnabled" == 0 ]]; then
 				result="Passed After Remediation"
 			else
 				result="Failed After Remediation"

--- a/Fragments/OrgScores/OrgScore2_1_1.sh
+++ b/Fragments/OrgScores/OrgScore2_1_1.sh
@@ -23,7 +23,7 @@ if [[ "${auditResult}" == "1" ]]; then
 	if [[ "$bluetoothEnabled" == 0 ]]; then
 		# bluetooth is off: passes
 		result="Passed"
-	elif [[ "$bluetoothEnabled" == 1 ]] && [[ "$connectable"-gt 0 ]]; then
+	elif [[ "$bluetoothEnabled" == 1 ]] && [[ "$connectable" -gt 0 ]]; then
 	        # bluetooth is on, and there are paired devices: passes
 		result="Passed"
 	else


### PR DESCRIPTION
Machine has Bluetooth off and two paired devices:
<img width="668" alt="image" src="https://user-images.githubusercontent.com/700560/136470476-6f69ade1-a50a-409a-ab15-24171c2cd70b.png">

Before: 
```
2.1.1 Turn off Bluetooth, if no paired devices exist (Automated) | 1 |   | Failed |   | Script | No Paired Devices
-- | -- | -- | -- | -- | -- | --
```

Scored as a failure and erroneously reports No Paired Devices

After:
```
2.1.1 Turn off Bluetooth, if no paired devices exist (Automated) | 1 |   | Passed |   | Script | Paired Devices: 2
-- | -- | -- | -- | -- | -- | --
```
Passes and correctly identifies two paired devices.