### PR TITLE
Permission changed to 400 to satisfy Jamf Protect Insight

### DIFF
--- a/Fragments/OrgScores/OrgScore3_4.sh
+++ b/Fragments/OrgScores/OrgScore3_4.sh
@@ -28,7 +28,7 @@ if [[ "${auditResult}" == "1" ]]; then
 			cp /etc/security/audit_control /etc/security/audit_control_old
 			oldExpireAfter=$(cat /etc/security/audit_control | egrep "expire-after")
 			sed "s/${oldExpireAfter}/expire-after:60d OR 1G/g" /etc/security/audit_control_old > /etc/security/audit_control
-			chmod 644 /etc/security/audit_control
+			chmod 400 /etc/security/audit_control
 			chown root:wheel /etc/security/audit_control
 			# re-check
 			auditRetention="$(grep -c "expire-after:60d OR 1G" /etc/security/audit_control)"	

--- a/Fragments/OrgScores/OrgScore3_5.sh
+++ b/Fragments/OrgScores/OrgScore3_5.sh
@@ -28,7 +28,7 @@ if [[ "${auditResult}" == "1" ]]; then
 		# Remediation
 		if [[ "${remediateResult}" == "enabled" ]]; then
 			chown -R root:wheel /var/audit
-			chmod -R 440 /var/audit
+			chmod -R 400 /var/audit
 			chown root:wheel /etc/security/audit_control
 			chmod 400 /etc/security/audit_control
 			# re-check


### PR DESCRIPTION
In order to satisfy Jamf Protect insight pertaining to audit record, permission needs to be set to 400