### PR TITLE
Updated airdrop orgscore for macOS 12 and fixed error within Jamf Pro JSON assembly

### DIFF
--- a/Fragments/OrgScores/OrgScore2_2_1.sh
+++ b/Fragments/OrgScores/OrgScore2_2_1.sh
@@ -6,7 +6,7 @@ projectfolder=$(dirname $script_dir)
 source ${projectfolder}/Header.sh
 
 CISLevel="1"
-audit='2.2.1 Ensure "Set time and date automatically" Is Enabled (Automated)'
+audit="2.2.1 Ensure 'Set time and date automatically' Is Enabled (Automated)"
 orgScore="OrgScore2_2_1"
 emptyVariables
 # Verify organizational score

--- a/Fragments/OrgScores/OrgScore2_4_11.sh
+++ b/Fragments/OrgScores/OrgScore2_4_11.sh
@@ -13,22 +13,43 @@ emptyVariables
 runAudit
 # If organizational score is 1 or true, check status of client
 if [[ "${auditResult}" == "1" ]]; then
-	method="Profile"
-	remediate="Configuration profile - payload > com.apple.applicationaccess > allowAirDrop=false"
+	if [[ "$osVersion" == "12."* ]]; then
+		method="Profile"
+		remediate="Configuration profile - payload > com.apple.NetworkBrowser > DisableAirDrop=true"
 
-	appidentifier="com.apple.applicationaccess"
-	value="allowAirDrop"
-	prefValue=$(getPrefValue "${appidentifier}" "${value}")
-	prefIsManaged=$(getPrefIsManaged "${appidentifier}" "${value}")
-	comment="AirDrop: Disabled"
-	if [[ "${prefIsManaged}" == "true" && "${prefValue}" == "false" ]]; then
-		result="Passed"
-	else
-		if [[ "${prefValue}" == "false" ]]; then
+		appidentifier="com.apple.NetworkBrowser"
+		value="DisableAirDrop"
+		prefValue=$(getPrefValue "${appidentifier}" "${value}")
+		prefIsManaged=$(getPrefIsManaged "${appidentifier}" "${value}")
+		comment="AirDrop: Disabled"
+			if [[ "${prefIsManaged}" == "true" && "${prefValue}" == "false" ]]; then
 			result="Passed"
 		else
-			result="Failed"
-			comment="AirDrop: Enabled"
+			if [[ "${prefValue}" == "false" ]]; then
+				result="Passed"
+			else
+				result="Failed"
+				comment="AirDrop: Enabled"
+			fi
+		fi
+	else
+		method="Profile"
+		remediate="Configuration profile - payload > com.apple.applicationaccess > allowAirDrop=false"
+
+		appidentifier="com.apple.applicationaccess"
+		value="allowAirDrop"
+		prefValue=$(getPrefValue "${appidentifier}" "${value}")
+		prefIsManaged=$(getPrefIsManaged "${appidentifier}" "${value}")
+		comment="AirDrop: Disabled"
+		if [[ "${prefIsManaged}" == "true" && "${prefValue}" == "false" ]]; then
+			result="Passed"
+		else
+			if [[ "${prefValue}" == "false" ]]; then
+				result="Passed"
+			else
+				result="Failed"
+				comment="AirDrop: Enabled"
+			fi
 		fi
 	fi
 fi

--- a/Fragments/OrgScores/OrgScore2_4_11.sh
+++ b/Fragments/OrgScores/OrgScore2_4_11.sh
@@ -22,10 +22,10 @@ if [[ "${auditResult}" == "1" ]]; then
 		prefValue=$(getPrefValue "${appidentifier}" "${value}")
 		prefIsManaged=$(getPrefIsManaged "${appidentifier}" "${value}")
 		comment="AirDrop: Disabled"
-			if [[ "${prefIsManaged}" == "true" && "${prefValue}" == "false" ]]; then
+			if [[ "${prefIsManaged}" == "true" && "${prefValue}" == "true" ]]; then
 			result="Passed"
 		else
-			if [[ "${prefValue}" == "false" ]]; then
+			if [[ "${prefValue}" == "true" ]]; then
 				result="Passed"
 			else
 				result="Failed"


### PR DESCRIPTION
macOS 12 adds DisableAirDrop=true within the com.apple.NetworkBrowser.plist